### PR TITLE
Fixed incorrect caps in API names

### DIFF
--- a/articles/project-management/schedule-api-preview.md
+++ b/articles/project-management/schedule-api-preview.md
@@ -40,9 +40,9 @@ The following is a list of current Project schedule APIs.
 - **msdyn_CreateProjectV1**: This API can be used to create a project. The project and default project bucket are created immediately.
 - **msdyn_CreateTeamMemberV1**: This API can be used to create a project team member. The team member record is created immediately.
 - **msdyn_CreateOperationSetV1**: This API can be used to schedule several requests that must be performed within a transaction.
-- **msdyn_PSSCreateV1**: This API can be used to create an entity. The entity can be any of the Project scheduling entities that support the create operation.
-- **msdyn_PSSUpdateV1**: This API can be used to update an entity. The entity can be any of the Project scheduling entities that support the update operation.
-- **msdyn_PSSDeleteV1**: This API can be used to delete an entity. The entity can be any of the Project scheduling entities that support the delete operation.
+- **msdyn_PssCreateV1**: This API can be used to create an entity. The entity can be any of the Project scheduling entities that support the create operation.
+- **msdyn_PssUpdateV1**: This API can be used to update an entity. The entity can be any of the Project scheduling entities that support the update operation.
+- **msdyn_PssDeleteV1**: This API can be used to delete an entity. The entity can be any of the Project scheduling entities that support the delete operation.
 - **msdyn_ExecuteOperationSetV1**: This API is used to execute all of the operations within the given operation set.
 
 ## Using Project schedule APIs with OperationSet


### PR DESCRIPTION
The schedule API names below have incorrect caps in the docs article compared to how they're named in Dataverse. Consistency in the API names is crucial.

Line 43 msdyn_PSSCreateV1 -> msdyn_PssCreateV1
![image](https://user-images.githubusercontent.com/64043240/182934188-775ba30f-5f60-41a3-850a-1450c5c4e65f.png)


Line 44 msdyn_PSSUpdateV1 -> msdyn_PssUpdateV1
![image](https://user-images.githubusercontent.com/64043240/182934310-856361d7-c9a7-43af-9a1e-6d82baf66b19.png)

Line 45 msdyn_PSSDeleteV1 -> msdyn_PssDeleteV1
![image](https://user-images.githubusercontent.com/64043240/182934244-e0b2af4e-405d-4a33-a4cc-a7706ef4c818.png)
