### PR TITLE
Removed ambiguous references

### DIFF
--- a/articles/environment/lite-preview-subscription-sign-up.md
+++ b/articles/environment/lite-preview-subscription-sign-up.md
@@ -58,9 +58,9 @@ Before you begin, make sure you are logged in to a browser with the user work ac
 
 ![Install Solution.](./media/21InstallSolution.png)
 
-## Install a CDS configuration and setup demo data
+## Set up demo data
 
-Install the CDS configuration and set up demo data by following instructions in the article, [Apply demo setup and configuration data](lite-apply-demo-setup-config-data.md).
+Set up demo data by following instructions in the article, [Apply demo setup and configuration data](lite-apply-demo-setup-config-data.md).
 
 
 [!INCLUDE[footer-include](../includes/footer-banner.md)]


### PR DESCRIPTION
"Install a CDS configuration" doesn't mean anything as it doesn't provide any context to what needs to be installed and because CDS is outdated terminology. It's best to just leave this at "set up demo data".