### PR TITLE
Line 31 updates to security roles

### DIFF
--- a/articles/approvals/approvals-security.md
+++ b/articles/approvals/approvals-security.md
@@ -28,6 +28,6 @@ To approve non-project entries, you must be the manager of the submitter.
 > [!NOTE]
 > The [Approval sets](approval-sets.md) feature must be enabled before you can use the Project Approver Admin functionality.
 
-The **Project Approver Admin** security role allows users to bypass policies and allows for the approval of entries across all projects. Assignment of this role will bypass the validation logic that requires team membership and being marked as an approver. You must have access to the relevant related entities, such as **Project**. That access can be assigned by someone who has the **Project Manager** role.
+The **Project Approver Admin** security role allows users to bypass policies and allows for the approval of entries across all projects. Assignment of this role will bypass the validation logic that requires team membership and being marked as an approver. You must have access to the relevant related tables, such as **Project**, via security roles assigned to you.
 
 The SYSTEM user context bypasses validations in the same way as the Project Approver Admin security role.


### PR DESCRIPTION
Changes on line 31:
- Entity -> table
-  The mention of a PM assigning access to the project table feels misleading when talking about security roles. I'd reword to mention that access to related tables is needed and that access is granted via the security roles assigned to the user. As we're talking security roles, it would be logical to mention that access is done through security as opposed a PM assignment.

Line 33:
More as a comment. This line needs more context. I've read this a few times but I fail to see how this information is relevant for this page. It needs more context.