### PR TITLE
Changed terminology on line 40

### DIFF
--- a/articles/pro/budget/create-delete-project-budget.md
+++ b/articles/pro/budget/create-delete-project-budget.md
@@ -37,7 +37,7 @@ To create a project cost budget, follow these steps.
 1. Sign in to Project Operations.
 1. In the left navigation, change the area to **Projects**.
 1. Select the project to create a budget for.
-1. On the project page, on the Action Pane, select **Create Budget**, and then follow these steps:
+1. On the command bar of the project's main form, select **Create Budget**, and then follow these steps:
 
     - To manually create the budget, select **Manual**. A **Budget** tab is added to the page and includes a blank grid for budget lines. 
     - To create budget lines, select **New Project Budget Line**.


### PR DESCRIPTION
Line 40 talks of pages and Action Panes, but these aren't Dataverse terminology or correct terminology in this context. Action Pages are AX based "ribbons" where as Dataverse has a "command bar": https://learn.microsoft.com/en-us/power-apps/maker/model-driven-apps/command-designer-overview

I've changed Action Pane to command bar and have removed the reference to a "page", which is incorrect terminology as opening a project lands us on a "form". I've reworded the sentence to describe that the command bar should be selected when on a project's main form.